### PR TITLE
Error on IE8 & IE9 due to setting router location to history

### DIFF
--- a/app/assets/javascripts/router.js
+++ b/app/assets/javascripts/router.js
@@ -10,5 +10,18 @@ App.Router.map(function() {
 });
 
 App.Router.reopen({
-  location: ('history' in window) ? 'history' : 'hash'
+  location: 'history'
 });
+
+// Fix supports IE9 use of Router.location history
+if (!window.history.pushState) {
+  Ember.LinkView.reopen({
+    click: function() {
+      window.location.replace(this.get('href'));
+    }
+  });
+
+  Ember.HistoryLocation.reopen({
+    replaceState: function() {}
+  });
+}


### PR DESCRIPTION
Need to check properties on window.history to really detect if IE8 or IE9.
